### PR TITLE
Allow to properly disconnect and reconnect the iOS KeyboardAutoManagerScroll at Runtime. 

### DIFF
--- a/ShanedlerSamples/Library/Keyboard/KeyboardAutoManagerScroll.iOS.cs
+++ b/ShanedlerSamples/Library/Keyboard/KeyboardAutoManagerScroll.iOS.cs
@@ -113,15 +113,30 @@ namespace Maui.FixesAndWorkarounds
 		public static void Disconnect()
 		{
 			if (WillShowToken is not null)
+			{
 				NSNotificationCenter.DefaultCenter.RemoveObserver(WillShowToken);
+				WillShowToken = null;
+			}
 			if (WillHideToken is not null)
+			{
 				NSNotificationCenter.DefaultCenter.RemoveObserver(WillHideToken);
+				WillHideToken = null;
+			}
 			if (DidHideToken is not null)
+			{
 				NSNotificationCenter.DefaultCenter.RemoveObserver(DidHideToken);
+				DidHideToken = null;
+			}
 			if (TextFieldToken is not null)
+			{
 				NSNotificationCenter.DefaultCenter.RemoveObserver(TextFieldToken);
+				TextFieldToken = null;
+			}
 			if (TextViewToken is not null)
+			{
 				NSNotificationCenter.DefaultCenter.RemoveObserver(TextViewToken);
+				TextViewToken = null;
+			}
 
 			IsKeyboardAutoScrollHandling = false;
 		}


### PR DESCRIPTION
If you would want do disonnect and reconnect at runtime: 

```csharp
Maui.FixesAndWorkarounds.KeyboardAutoManagerScroll.Disconnect(); 
//and then later:
Maui.FixesAndWorkarounds.KeyboardAutoManagerScroll.Connect();
```

That would not be possible, even though the Connect and Disconnect methods are public. When you invoke the Disconnect, but then try to Connect again, the `Connect` logic will stop you since `TextFieldToken` is still `not null` even though the Notification Center observers have been removed. 